### PR TITLE
Release Linux/ARM64 Tendermint Docker Image

### DIFF
--- a/.github/workflows/docker.yml
+++ b/.github/workflows/docker.yml
@@ -14,9 +14,6 @@ jobs:
   build:
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/setup-go@v2
-        with:
-          go-version: "1.15"
       - uses: actions/checkout@master
       - name: Prepare
         id: prep
@@ -37,6 +34,11 @@ jobs:
           fi
           echo ::set-output name=tags::${TAGS}
 
+      - name: Set up QEMU
+        uses: docker/setup-qemu-action@master
+        with:
+          platforms: all
+
       - name: Set up Docker Buildx
         uses: docker/setup-buildx-action@v1
 
@@ -46,14 +48,11 @@ jobs:
           username: ${{ secrets.DOCKERHUB_USERNAME }}
           password: ${{ secrets.DOCKERHUB_TOKEN }}
 
-      - name: Build Tendermint
-        run: |
-          make build-linux && cp build/tendermint DOCKER/tendermint
-
       - name: Publish to Docker Hub
         uses: docker/build-push-action@v2
         with:
-          context: ./DOCKER
+          context: .
           file: ./DOCKER/Dockerfile
+          platforms: linux/amd64,linux/arm64
           push: ${{ github.event_name != 'pull_request' }}
           tags: ${{ steps.prep.outputs.tags }}

--- a/DOCKER/Dockerfile
+++ b/DOCKER/Dockerfile
@@ -1,4 +1,14 @@
-FROM alpine:3.9
+# stage 1 Generate Tendermint Binary
+FROM golang:1.15-alpine as builder
+RUN apk update && \
+    apk upgrade && \
+    apk --no-cache add make
+COPY / /tendermint
+WORKDIR /tendermint
+RUN make build-linux
+
+# stage 2
+FROM golang:1.15-alpine
 LABEL maintainer="hello@tendermint.com"
 
 # Tendermint will be looking for the genesis file in /tendermint/config/genesis.json
@@ -15,7 +25,7 @@ ENV TMHOME /tendermint
 # could execute bash commands.
 RUN apk update && \
     apk upgrade && \
-    apk --no-cache add curl jq bash && \
+    apk --no-cache add curl jq bash make && \
     addgroup tmuser && \
     adduser -S -G tmuser tmuser -h "$TMHOME"
 
@@ -29,15 +39,14 @@ EXPOSE 26656 26657 26660
 
 STOPSIGNAL SIGTERM
 
-ARG BINARY=tendermint
-COPY $BINARY /usr/bin/tendermint
+COPY --from=builder /tendermint/build/tendermint /usr/bin/tendermint
 
 # You can overwrite these before the first run to influence
 # config.json and genesis.json. Additionally, you can override
 # CMD to add parameters to `tendermint node`.
 ENV PROXY_APP=kvstore MONIKER=dockernode CHAIN_ID=dockerchain
 
-COPY ./docker-entrypoint.sh /usr/local/bin/
+COPY ./DOCKER/docker-entrypoint.sh /usr/local/bin/
 
 ENTRYPOINT ["docker-entrypoint.sh"]
 CMD ["start"]

--- a/DOCKER/Dockerfile
+++ b/DOCKER/Dockerfile
@@ -25,7 +25,7 @@ ENV TMHOME /tendermint
 # could execute bash commands.
 RUN apk update && \
     apk upgrade && \
-    apk --no-cache add curl jq bash make && \
+    apk --no-cache add curl jq bash && \
     addgroup tmuser && \
     adduser -S -G tmuser tmuser -h "$TMHOME"
 


### PR DESCRIPTION
**Hi**

**Package Owner:** Rahul Aggarwal

**PR change Details:**

**1. Patch Details:** Following 2 files have been modified :

**Dockerfile:** Changed the base image to incorporate go1.15 installation, added build tendermint part to this file, to generate Linux/ARM64 binary and copied it to the desired location.
**docker.yml:** Removed the go installation and build tendermint part, as those have been included in the Dockerfile. Installed QEMU and added platforms to the buildx, to release linux AMD64 and ARM64 docker images. Chnaged the context to the root of the project, to ease the build tendermint process in the Dockerfile.

**2. Testing Detail:**
Please find my dockerhub releases here: <https://hub.docker.com/r/pshub/tendermint_unified_004/tags?page=1&ordering=last_updated>

**3. PR Description:** Here is my commit message :

1. The build tendermint process has been added to the Dockerfile because github actions do not support direct AArch64 builds, and we require the tendermint binary to build tendermint docker image for both the platforms.
2. Installed QEMU via docker.yml file, and added platforms as "linux/amd64" and "linux/arm64" to the buildx, to release both architecture specific docker images for tendermint. Changed the context to the root of the package, to ease the build tendermint process via Dockerfile.
3. Added the build tendermint part to the Dockerfile in stage 1, and copied the generated binary to the desired location in stage 2. Changed the base image to "golang:1.15-alpine", to incorporate the go1.15 installation.

Signed-off-by: odidev <odidev@puresoftware.com>


**4. Reviewer:** Pruthvi Teja Reddy & Shobhit Parashari

**Thanks
Rahul Aggarwal**

